### PR TITLE
Add pip ecosystem to dependabot for auto update of python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
* add pip ecosystem to dependabot.yml
* update the dependabot update schedule to Fridays