### PR TITLE
Update permissions publish docs job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,6 +116,10 @@ jobs:
     name: Publish Documentation
     if: ${{ needs.smoke_test_pypi.result == 'success' }}
     needs: smoke_test_pypi
+    permissions:
+      pages: write     # to deploy to GitHub Pages
+      id-token: write  # to verify the deployment
+
     uses: ./.github/workflows/docs_build.yml
     with:
       deploy: true


### PR DESCRIPTION
The publish workflow has some permission issues where the caller workflow is not granting the required permissions to the reusable workflow responsible for building and publishing docs site.