### PR TITLE
Update Artifact Name for Docs

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set Artifact Name
         id: artifact-name
         run: |
-          echo "artifact_name=${{ github.run_id }}[${{ github.run_attempt }}]--build-artifacts" \
+          echo "artifact_name=${{ github.run_id }}[${{ github.run_attempt }}]--docs-artifacts" \
           | tee -a $GITHUB_OUTPUT
 
       - name: Upload Pages Artifacts


### PR DESCRIPTION
The docs artifact name is same as the build artifact name. This will cause the collisions in artifact name and fail the workflow when the `.github/workflows/dist_build.yml` and `.github/workflows/docs_build.yml` are called from same workflow using the `workflow_call` trigger.
This should fix this issue by making the artifact names unique.