### PR TITLE
Add bug report issue template with --debug option in cli

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug Report
+description: Report a bug in pyDOE
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please provide the information below to help us diagnose and fix the issue quickly.
+
+  - type: textarea
+    id: debug_info
+    attributes:
+      label: Environment
+      description: "Output of pydoe --debug command"
+      placeholder: |
+        ### Debug Info
+
+        | Field | Value |
+        |-------|-------|
+        | PyDOE | 1.0.1 |
+        | Python | 3.12.3 (CPython) |
+        | OS | Linux |
+        | OS Release | 6.12.88 |
+        | Architecture | x86_64 |
+        | NumPy | 2.2.6 |
+        | SciPy | 1.15.3 |
+        | Install Source | pypi |
+    validations:
+      required: true
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: Which method are you using?
+      options:
+        - "fullfact / ff2n / fracfact / pbdesign"
+        - "bbdesign / ccdesign / doehlert / star"
+        - "lhs / sobol_sequence / halton_sequence"
+        - "optimal_design / sequential_dykstra / fedorov"
+        - "taguchi_design / get_orthogonal_array"
+        - "morris_sampling / saltelli_sampling"
+        - "doe_sparse_grid"
+        - "random_k_means"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: "What should happen?"
+      placeholder: "The design matrix should have shape (12, 3) with values in [-1, 1]"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: "What actually happens instead?"
+      placeholder: "The design matrix has shape (12, 2) instead of (12, 3)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error traceback (if applicable)
+      description: "Paste the full traceback here if an exception occurred"
+      placeholder: |
+        ```
+        Traceback (most recent call last):
+          File "...", line X, in <module>
+            result = pydoe.fullfact([2, 3, 2])
+        ValueError: ...
+        ```
+
+  - type: textarea
+    id: minimal_example
+    attributes:
+      label: Minimal reproducible example
+      description: "Smallest code snippet that reproduces the issue"
+      placeholder: |
+        ```python
+        import pydoe
+        import numpy as np
+
+        result = pydoe.fullfact([2, 3, 2])
+        print(result.shape)
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: "What were you trying to accomplish? Any relevant details about input data, workarounds, or frequency?"
+      placeholder: "I was trying to design a 6-factor experiment with Box-Behnken..."

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -29,8 +29,8 @@ jobs:
           args: --version
 
       - name: Enforce Lint
-        run: ruff check pydoe/ pyproject.toml
+        run: ruff check .
 
       - name: Enforce Format
         run: |
-          ruff format --diff pydoe/ pyproject.toml
+          ruff format --diff .

--- a/pydoe/__main__.py
+++ b/pydoe/__main__.py
@@ -1,0 +1,5 @@
+from pydoe.debug import main
+
+
+if __name__ == "__main__":
+    main()

--- a/pydoe/debug.py
+++ b/pydoe/debug.py
@@ -1,0 +1,149 @@
+"""Debug utilities for PyDOE: environment introspection for bug reports."""
+
+import argparse
+import json
+import os
+import platform
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def _get_version(package_name: str) -> str:
+    """Get package version or 'unknown' if not found.
+
+    Parameters
+    ----------
+    package_name : str
+        Name of the package.
+
+    Returns
+    -------
+    str
+        Version string or 'unknown' if not found.
+    """
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _detect_install_source() -> str:
+    """Detect whether pydoe was installed via conda, pypi, or editable.
+
+    Returns
+    -------
+    str
+        One of: "conda", "editable (dev)", or "pypi".
+    """
+    conda_meta_path = os.path.join(sys.prefix, "conda-meta")
+    if os.path.isdir(conda_meta_path):
+        return "conda"
+
+    # Check for editable installation
+    py_ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    site_packages = Path(sys.prefix) / "lib" / py_ver / "site-packages"
+    pydoe_dist_info = site_packages.glob("pydoe-*.dist-info")
+    for dist_info in pydoe_dist_info:
+        direct_url_path = dist_info / "direct_url.json"
+        if direct_url_path.exists():
+            try:
+                with open(direct_url_path, encoding="utf-8") as f:
+                    direct_url = json.load(f)
+                    if direct_url.get("editable"):
+                        return "editable (dev)"
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    return "pypi"
+
+
+def debug_info() -> dict:
+    """Collect environment and package information for bug reports.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys: pydoe, python, python_impl, os, os_release,
+        architecture, numpy, scipy, install_source.
+    """
+    return {
+        "pydoe": _get_version("pydoe"),
+        "python": f"{sys.version.split()[0]}",
+        "python_impl": platform.python_implementation(),
+        "os": platform.system(),
+        "os_release": platform.release(),
+        "architecture": platform.machine(),
+        "numpy": _get_version("numpy"),
+        "scipy": _get_version("scipy"),
+        "install_source": _detect_install_source(),
+    }
+
+
+def format_debug_output(info: dict) -> str:
+    """Format debug info as a markdown table.
+
+    Parameters
+    ----------
+    info : dict
+        Dictionary from debug_info().
+
+    Returns
+    -------
+    str
+        Markdown-formatted table, ready to paste into GitHub issues.
+    """
+    lines = ["### Debug Info", "", "| Field | Value |", "|-------|-------|"]
+
+    field_names = {
+        "pydoe": "PyDOE",
+        "python": "Python",
+        "python_impl": "Python Implementation",
+        "os": "OS",
+        "os_release": "OS Release",
+        "architecture": "Architecture",
+        "numpy": "NumPy",
+        "scipy": "SciPy",
+        "install_source": "Install Source",
+    }
+
+    for key in [
+        "pydoe",
+        "python",
+        "python_impl",
+        "os",
+        "os_release",
+        "architecture",
+        "numpy",
+        "scipy",
+        "install_source",
+    ]:
+        lines.append(f"| {field_names[key]} | `{info[key]}` |")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="PyDOE utilities", prog="pydoe"
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_get_version('pydoe')}",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Print debug information for bug reports",
+    )
+
+    args = parser.parse_args()
+
+    if args.debug:
+        info = debug_info()
+        output = format_debug_output(info)
+        print(output)
+    elif not sys.argv[1:]:
+        parser.print_help()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ changelog = "https://pydoe.github.io/pydoe/changelog/"
 releasenotes = "https://github.com/pydoe/pydoe/releases/latest"
 issues = "https://github.com/pydoe/pydoe/issues"
 
+[project.scripts]
+pydoe = "pydoe.debug:main"
+
 [dependency-groups]
 dev = [
   {include-group = "docs"},


### PR DESCRIPTION
### Summary

This PR adds a command-line interface to pydoe that helps users quickly gather environment and package information for bug reports. The new `pydoe --debug` command outputs a formatted table with Python version, OS, architecture, package versions, and install source—critical details for reproducing and debugging issues.

Alongside the CLI, we provide an interactive GitHub issue form template that guides users to include this diagnostic data and a minimal reproducible example, significantly reducing the back-and-forth needed to diagnose bugs.

### Usage

```bash
# Display environment details
pydoe --debug
```
OR

```python
from pydoe.debug import debug_info, format_debug_output

info = debug_info()
output = format_debug_output(info)
print(output)
```

### Example Output

```
### Debug Info

| Field | Value |
|-------|-------|
| PyDOE | 1.0.3 |
| Python | 3.13.5 |
| Python Implementation | CPython |
| OS | Linux |
| OS Release | 6.12.88+deb13-amd64 |
| Architecture | x86_64 |
| NumPy | 2.4.4 |
| SciPy | 1.17.1 |
| Install Source | pypi |
```

### Benefits

1. Users can quickly gather required diagnostic information in one command
2. Conda vs PyPI install detection helps diagnose binary compatibility issues (different builds of NumPy/SciPy)
3. Interactive issue form enforces collection of minimal reproducible examples and parameters
4. Reduces back-and-forth communication on bug reports by ensuring critical information is included upfront
5. Maintainers can reproduce issues faster with complete environment details
