### PR TITLE
Update CLAUDE.md architecture overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,16 +42,19 @@ PyDOE is a Design of Experiments library. **Every public symbol is re-exported t
 
 | Subpackage | Contents |
 |---|---|
-| `pydoe/factorial/` | Full/fractional factorial (`fullfact`, `ff2n`, `fracfact*`), Plackett-Burman, GSD, fold-over |
-| `pydoe/response_surface/` | Box-Behnken, central composite (CCD), Doehlert, star, union, repeat_center |
-| `pydoe/space_filling/quasi_random/` | Low-discrepancy sequences: Sobol', Halton, Korobov, rank-1 lattice, Sukharev, Cranley-Patterson |
-| `pydoe/space_filling/stochastic/` | Latin hypercube (`lhs`), random uniform |
+| `pydoe/factorial/` | Full/fractional factorial (`fullfact`, `ff2n`, `fracfact*`), Plackett-Burman, GSD, fold-over, Latin/Graeco-Latin square, John's 3/4 fractional factorial, blocking |
+| `pydoe/mixture/` | Simplex-lattice/centroid, axial (screening), extreme-vertices, mixture+process-variable designs |
+| `pydoe/response_surface/` | Box-Behnken, central composite (CCD), Doehlert, star, union, repeat_center, small composite, blocking |
+| `pydoe/space_filling/quasi_random/` | Low-discrepancy sequences: Sobol', Halton, Hammersley, Korobov, rank-1 lattice, Sukharev, Faure, Niederreiter, Cranley-Patterson |
+| `pydoe/space_filling/stochastic/` | Latin hypercube (`lhs`), OA-LHD, sliced/nested LHS, maximin/minimax distance designs, MaxPro, nearly-orthogonal LHS, random uniform |
+| `pydoe/sequential/` | Adaptive/Bayesian-optimization designs: `sequential_design`, `GaussianProcessRegressor`, acquisition functions (EI, PI, UCB) |
 | `pydoe/optimal/` | Optimal design algorithms and all optimality criteria |
 | `pydoe/taguchi/` | Taguchi orthogonal arrays (data files in `orthogonal_arrays/`), SNR, `TaguchiObjective` |
 | `pydoe/sensitivity_analysis/` | Morris method, Saltelli sampling |
 | `pydoe/clustering/` | Random K-means sampling |
 | `pydoe/sparse_grid/` | Sparse grid designs |
-| `pydoe/utils/` | `scale_samples` (unit-hypercube → arbitrary bounds), `var_regression_matrix` |
+| `pydoe/specialized/` | Definitive screening designs, supersaturated designs |
+| `pydoe/utils/` | `scale_samples` (unit-hypercube → arbitrary bounds), `var_regression_matrix`, `iman_conover` |
 | `pydoe/debug.py` | CLI entrypoint (`pydoe --debug`) for printing environment info |
 
 ## Optimal Design Module (`pydoe/optimal/`)
@@ -74,6 +77,20 @@ During iterative search the algorithms evaluate criterion values for many interm
 3. Falling back to Tikhonov regularization: `M_reg = M + λI` where `λ = 1e-8`, which shifts all eigenvalues up by `λ` and guarantees positive-definiteness.
 
 **Important**: `scipy.linalg.inv` emits `LinAlgWarning` for ill-conditioned matrices but only raises `LinAlgError` for exactly singular ones. The original `except np.linalg.LinAlgError` pattern was therefore dead code for the ill-conditioned case.
+
+## Sequential / Adaptive Design Module (`pydoe/sequential/`)
+
+`sequential_design()` (in `adaptive.py`) drives a Bayesian-optimization
+loop: it builds an initial space-filling design via
+`space_filling.stochastic.lhs` + `utils.scale_samples`, fits a
+`GaussianProcessRegressor` (RBF kernel, in `gaussian_process.py`) to the
+observations, and at each iteration scores random candidates with one of
+the acquisition functions in `acquisition.py` (`expected_improvement`,
+`probability_of_improvement`, `upper_confidence_bound`) to pick the next
+evaluation point. All GP fitting/prediction is done on inputs normalized
+to `[0, 1]^d` so `length_scale` stays meaningful regardless of `bounds`.
+Acquisition functions always return "higher = more promising" scores,
+even when `maximize=False`.
 
 ## Sobol' Sequence and Saltelli Sampling
 


### PR DESCRIPTION
Documents the mixture, sequential, and specialized subpackages and expands the space-filling/quasi-random module descriptions to cover the new MaxPro, NOLH, distance-design, Faure, and Niederreiter implementations.