### PR TITLE
chore: update ignore directives for Ruff 0.16, using ruff check --fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,10 @@ Ruff enforces strict rules. Notable ones:
 - `PLR2004` — **ignored**: magic number comparisons allowed.
 - `S311` — **ignored**: non-cryptographic random usage allowed.
 
-Line length is 80. Functions that genuinely need many arguments carry `# noqa: PLR0913` (too many args) or `# noqa: PLR0912` (too many branches).
+Line length is 80. Do not use `# noqa` suppression comments. When a suppression
+is genuinely necessary, use Ruff's human-readable form, such as
+`# ruff: ignore[too-many-arguments]` or
+`# ruff: ignore[too-many-branches]`.
 
 ## Documentation
 

--- a/pydoe/__init__.py
+++ b/pydoe/__init__.py
@@ -125,7 +125,7 @@ from .taguchi import (
 from .utils import iman_conover, scale_samples, var_regression_matrix
 
 
-try:  # ruff: ignore[non-empty-init-module]
+try:
     __version__ = version(__name__)
 except PackageNotFoundError:
     __version__ = "unknown"

--- a/pydoe/__init__.py
+++ b/pydoe/__init__.py
@@ -125,7 +125,7 @@ from .taguchi import (
 from .utils import iman_conover, scale_samples, var_regression_matrix
 
 
-try:  # noqa: RUF067
+try:  # ruff: ignore[non-empty-init-module]
     __version__ = version(__name__)
 except PackageNotFoundError:
     __version__ = "unknown"

--- a/pydoe/clustering/k_means_sampling.py
+++ b/pydoe/clustering/k_means_sampling.py
@@ -6,7 +6,7 @@ from warnings import warn
 import numpy as np
 
 
-def random_k_means(  # noqa: PLR0913, PLR0917
+def random_k_means(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     num_points: int,
     dimension: int,
     num_steps: int | None = None,

--- a/pydoe/factorial/factorial.py
+++ b/pydoe/factorial/factorial.py
@@ -560,7 +560,7 @@ def _n_fac_at_res(n: int, res: int) -> int:
 ################################################################################
 
 
-def fracfact_opt(  # noqa: PLR0914
+def fracfact_opt(  # ruff: ignore[too-many-locals]
     n_factors: int, n_erased: int, max_attempts: int = 0
 ) -> tuple[str, list[str], np.ndarray]:
     """

--- a/pydoe/factorial/factorial.py
+++ b/pydoe/factorial/factorial.py
@@ -560,7 +560,7 @@ def _n_fac_at_res(n: int, res: int) -> int:
 ################################################################################
 
 
-def fracfact_opt(  # ruff: ignore[too-many-locals]
+def fracfact_opt(
     n_factors: int, n_erased: int, max_attempts: int = 0
 ) -> tuple[str, list[str], np.ndarray]:
     """

--- a/pydoe/optimal/algorithms.py
+++ b/pydoe/optimal/algorithms.py
@@ -129,7 +129,7 @@ def sequential_dykstra(
     return design
 
 
-def simple_exchange_wynn_mitchell(  # noqa: PLR0913, PLR0917
+def simple_exchange_wynn_mitchell(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     candidates: np.ndarray,
     n_points: int,
     degree: int,
@@ -205,7 +205,7 @@ def simple_exchange_wynn_mitchell(  # noqa: PLR0913, PLR0917
     return design
 
 
-def fedorov(  # noqa: PLR0913, PLR0917
+def fedorov(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     candidates: np.ndarray,
     n_points: int,
     degree: int,
@@ -278,7 +278,7 @@ def fedorov(  # noqa: PLR0913, PLR0917
     return design
 
 
-def modified_fedorov(  # noqa: PLR0913, PLR0917
+def modified_fedorov(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     candidates: np.ndarray,
     n_points: int,
     degree: int,
@@ -353,7 +353,7 @@ def modified_fedorov(  # noqa: PLR0913, PLR0917
     return design
 
 
-def detmax(  # noqa: PLR0913, PLR0914, PLR0917
+def detmax(  # ruff: ignore[too-many-arguments, too-many-locals, too-many-positional-arguments]
     candidates: np.ndarray,
     n_points: int,
     degree: int,

--- a/pydoe/optimal/algorithms.py
+++ b/pydoe/optimal/algorithms.py
@@ -353,7 +353,7 @@ def modified_fedorov(  # ruff: ignore[too-many-arguments, too-many-positional-ar
     return design
 
 
-def detmax(  # ruff: ignore[too-many-arguments, too-many-locals, too-many-positional-arguments]
+def detmax(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     candidates: np.ndarray,
     n_points: int,
     degree: int,

--- a/pydoe/optimal/model.py
+++ b/pydoe/optimal/model.py
@@ -45,7 +45,7 @@ $$X =
 1 & 1 & -1 & 1 & 1 & -1 \\
 1 & 1 & 1 & 1 & 1 & 1 \\
 \end{bmatrix}$$
-"""  # noqa: E501
+"""  # ruff: ignore[line-too-long]
 
 from __future__ import annotations
 
@@ -91,7 +91,7 @@ def build_design_matrix(candidates: np.ndarray, degree: int) -> np.ndarray:
 
     where $k$ is the number of factors, $x_i$ are the input variables, and $\beta$ are
     the model parameters.
-    """  # noqa: E501
+    """  # ruff: ignore[line-too-long]
     candidates = np.asarray(candidates, dtype=float)
     n_points, n_factors = candidates.shape
 

--- a/pydoe/optimal/optimal.py
+++ b/pydoe/optimal/optimal.py
@@ -16,7 +16,7 @@ from pydoe.optimal.model import build_design_matrix, build_uniform_moment_matrix
 from pydoe.optimal.utils import criterion_value
 
 
-def optimal_design(  # noqa: PLR0913, PLR0917
+def optimal_design(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     candidates: np.ndarray,
     n_points: int,
     degree: int,

--- a/pydoe/optimal/utils.py
+++ b/pydoe/optimal/utils.py
@@ -46,7 +46,7 @@ def _xtx_augmented(
     if alpha and X0 is not None and len(X0) > 0:
         N0 = X0.shape[0]
         H0 = (X0.T @ X0) / N0
-        H = H + alpha * H0  # ruff: ignore[non-augmented-assignment]
+        H = H + alpha * H0
     return H
 
 

--- a/pydoe/optimal/utils.py
+++ b/pydoe/optimal/utils.py
@@ -41,12 +41,12 @@ def _xtx_augmented(
     -------
     ndarray of shape (p, p)
         Augmented information matrix.
-    """  # noqa: E501
+    """  # ruff: ignore[line-too-long]
     H = X.T @ X
     if alpha and X0 is not None and len(X0) > 0:
         N0 = X0.shape[0]
         H0 = (X0.T @ X0) / N0
-        H = H + alpha * H0  # noqa: PLR6104
+        H = H + alpha * H0  # ruff: ignore[non-augmented-assignment]
     return H
 
 
@@ -76,13 +76,13 @@ def information_matrix(
     -------
     ndarray of shape (p, p)
         Information matrix.
-    """  # noqa: E501
+    """  # ruff: ignore[line-too-long]
     n = X.shape[0]
     H_aug = _xtx_augmented(X, alpha=alpha, X0=X0)
     return H_aug / n if normalized else H_aug
 
 
-def criterion_value(  # noqa: PLR0911
+def criterion_value(  # ruff: ignore[too-many-return-statements]
     X: np.ndarray,
     criterion: Literal["D", "A", "I", "C", "E", "G", "V", "S", "T"],
     X0: np.ndarray = None,
@@ -153,7 +153,7 @@ def criterion_value(  # noqa: PLR0911
         raise ValueError(f"Unknown criterion: {criterion}")
 
 
-def _best_single_add(  # noqa: PLR0913, PLR0917
+def _best_single_add(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     current: np.ndarray,
     pool: np.ndarray,
     degree: int,
@@ -206,7 +206,7 @@ def _best_single_add(  # noqa: PLR0913, PLR0917
     return best_idx, best_val
 
 
-def _best_single_drop(  # noqa: PLR0913, PLR0917
+def _best_single_drop(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     current: np.ndarray,
     degree: int,
     criterion: str,

--- a/pydoe/sensitivity_analysis/saltelli.py
+++ b/pydoe/sensitivity_analysis/saltelli.py
@@ -48,7 +48,7 @@ from pydoe.space_filling.quasi_random.sobol import sobol_sequence
 __all__ = ["saltelli_sampling"]
 
 
-def saltelli_sampling(  # noqa: PLR0913
+def saltelli_sampling(  # ruff: ignore[too-many-arguments]
     num_vars: int,
     N: int,
     *,

--- a/pydoe/sequential/adaptive.py
+++ b/pydoe/sequential/adaptive.py
@@ -35,7 +35,7 @@ from pydoe.utils import scale_samples
 __all__ = ["sequential_design"]
 
 
-def sequential_design(  # ruff: ignore[too-many-arguments, too-many-locals]
+def sequential_design(  # ruff: ignore[too-many-arguments]
     objective: Callable[[np.ndarray], float],
     bounds: np.ndarray,
     n_initial: int,

--- a/pydoe/sequential/adaptive.py
+++ b/pydoe/sequential/adaptive.py
@@ -35,7 +35,7 @@ from pydoe.utils import scale_samples
 __all__ = ["sequential_design"]
 
 
-def sequential_design(  # noqa: PLR0913, PLR0914
+def sequential_design(  # ruff: ignore[too-many-arguments, too-many-locals]
     objective: Callable[[np.ndarray], float],
     bounds: np.ndarray,
     n_initial: int,

--- a/pydoe/space_filling/quasi_random/sobol.py
+++ b/pydoe/space_filling/quasi_random/sobol.py
@@ -29,7 +29,7 @@ from scipy.stats import qmc
 __all__ = ["sobol_sequence"]
 
 
-def sobol_sequence(  # noqa: PLR0913
+def sobol_sequence(  # ruff: ignore[too-many-arguments]
     n: int,
     d: int,
     *,

--- a/pydoe/space_filling/stochastic/lhs.py
+++ b/pydoe/space_filling/stochastic/lhs.py
@@ -316,7 +316,7 @@ def _lhscorrelate(
 ################################################################################
 
 
-def _lhsmu(  # ruff: ignore[too-many-locals]
+def _lhsmu(
     N: int,
     samples: int | None = None,
     corr: np.ndarray = None,

--- a/pydoe/space_filling/stochastic/lhs.py
+++ b/pydoe/space_filling/stochastic/lhs.py
@@ -26,7 +26,7 @@ from scipy import linalg, spatial, stats
 __all__ = ["lhs"]
 
 
-def lhs(  # noqa: PLR0912, PLR0913, PLR0917
+def lhs(  # ruff: ignore[too-many-branches, too-many-arguments, too-many-positional-arguments]
     n: int,
     samples: int | None = None,
     criterion: Literal[
@@ -316,7 +316,7 @@ def _lhscorrelate(
 ################################################################################
 
 
-def _lhsmu(  # noqa: PLR0914
+def _lhsmu(  # ruff: ignore[too-many-locals]
     N: int,
     samples: int | None = None,
     corr: np.ndarray = None,
@@ -326,7 +326,7 @@ def _lhsmu(  # noqa: PLR0914
     if samples is None:
         samples = N
 
-    I = M * samples  # noqa: E741
+    I = M * samples  # ruff: ignore[ambiguous-variable-name]
 
     rdpoints = randomstate.uniform(size=(I, N))
 
@@ -370,7 +370,7 @@ def _lhsmu(  # noqa: PLR0914
         H = np.zeros_like(rdpoints, dtype=float)
         rank = np.argsort(rdpoints, axis=0)
 
-        for l in range(samples):  # noqa: E741
+        for l in range(samples):  # ruff: ignore[ambiguous-variable-name]
             low = float(l) / samples
             high = float(l + 1) / samples
 

--- a/pydoe/sparse_grid/sparse_grid.py
+++ b/pydoe/sparse_grid/sparse_grid.py
@@ -99,7 +99,7 @@ def sparse_grid_dimension(n_level: int, n_factors: int) -> int:
     return _spdim_formula(n_level, n_factors)
 
 
-def _spdim_formula(n: int, d: int) -> int:  # noqa: PLR0911
+def _spdim_formula(n: int, d: int) -> int:  # ruff: ignore[too-many-return-statements]
     """
     Sparse grid dimension formulas from MATLAB spinterp spdim function.
 
@@ -167,7 +167,7 @@ def _spdim_formula(n: int, d: int) -> int:  # noqa: PLR0911
         )
 
 
-def _generate_sparse_grid_points(  # noqa: PLR0912
+def _generate_sparse_grid_points(  # ruff: ignore[too-many-branches]
     n_level: int, n_factors: int, grid_type: str
 ) -> np.ndarray:
     target_count = _spdim_formula(n_level, n_factors)
@@ -190,7 +190,7 @@ def _generate_sparse_grid_points(  # noqa: PLR0912
                 points.append(point)
 
     # Level 2+: structured interior points
-    if n_level >= 2:  # noqa: PLR1702
+    if n_level >= 2:  # ruff: ignore[too-many-nested-blocks]
         grid_size = min(n_level + 2, 7)
         coords = np.linspace(0, 1, grid_size)
 

--- a/pydoe/sparse_grid/sparse_grid.py
+++ b/pydoe/sparse_grid/sparse_grid.py
@@ -190,7 +190,7 @@ def _generate_sparse_grid_points(  # ruff: ignore[too-many-branches]
                 points.append(point)
 
     # Level 2+: structured interior points
-    if n_level >= 2:  # ruff: ignore[too-many-nested-blocks]
+    if n_level >= 2:
         grid_size = min(n_level + 2, 7)
         coords = np.linspace(0, 1, grid_size)
 

--- a/pydoe/utils/build_regression_matrix.py
+++ b/pydoe/utils/build_regression_matrix.py
@@ -30,7 +30,7 @@ def grep(haystack: str, needle: str) -> Iterator[int]:
         start += len(needle)
 
 
-def build_regression_matrix(  # noqa: PLR0912
+def build_regression_matrix(  # ruff: ignore[too-many-branches]
     H: np.ndarray, model: str, build: np.ndarray[np.bool_] = None
 ) -> np.ndarray:
     """
@@ -105,11 +105,11 @@ def build_regression_matrix(  # noqa: PLR0912
     if vector_mode:
         R = np.zeros((len(list_of_tokens), 1))
         for j in range(len(list_of_tokens)):
-            R[j, 0] = eval(list_of_tokens[j])  # noqa: S307
+            R[j, 0] = eval(list_of_tokens[j])  # ruff: ignore[suspicious-eval-usage]
     else:
         R = np.zeros((H.shape[0], len(list_of_tokens)))
         for i in range(H.shape[0]):
             for j in range(len(list_of_tokens)):
-                R[i, j] = eval(list_of_tokens[j])  # noqa: S307
+                R[i, j] = eval(list_of_tokens[j])  # ruff: ignore[suspicious-eval-usage]
 
     return R

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ preview = true
 output-format = "grouped"
 
 [tool.ruff.lint]
+explicit-preview-rules = true
 isort.lines-after-imports = 2
 isort.split-on-trailing-comma = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,22 +120,22 @@ select = [
 ]
 
 ignore = [
-    "N803",      # [pep8-naming](https://docs.astral.sh/ruff/rules/invalid-argument-name/)
-    "N806",      # [pep8-naming](https://docs.astral.sh/ruff/rules/non-lowercase-variable-in-function/)
-    "PLR2004",   # [pylint](https://docs.astral.sh/ruff/rules/magic-value-comparison/)
-    "S311",      # [flake8-bandit](https://docs.astral.sh/ruff/rules/suspicious-non-cryptographic-random-usage/)
+    "invalid-argument-name",      # [pep8-naming](https://docs.astral.sh/ruff/rules/invalid-argument-name/)
+    "non-lowercase-variable-in-function",      # [pep8-naming](https://docs.astral.sh/ruff/rules/non-lowercase-variable-in-function/)
+    "magic-value-comparison",   # [pylint](https://docs.astral.sh/ruff/rules/magic-value-comparison/)
+    "suspicious-non-cryptographic-random-usage",      # [flake8-bandit](https://docs.astral.sh/ruff/rules/suspicious-non-cryptographic-random-usage/)
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
-    "ANN001",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-type-function-argument/)
-    "ANN201",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/)
-    "ANN202",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-return-type-private-function/)
-    "S101",       # [flake8-bandit](https://docs.astral.sh/ruff/rules/assert/)
-    "N802",       # [pep8-naming](https://docs.astral.sh/ruff/rules/invalid-function-name/)
-    "N803",       # [pep8-naming](https://docs.astral.sh/ruff/rules/invalid-argument-name/)
-    "N806",       # [pep8-naming](https://docs.astral.sh/ruff/rules/non-lowercase-variable-in-function/)
-    "PLR6301",    # [pylint](https://docs.astral.sh/ruff/rules/no-self-use/)
+    "missing-type-function-argument",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-type-function-argument/)
+    "missing-return-type-undocumented-public-function",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/)
+    "missing-return-type-private-function",     # [flake8-annotations](https://docs.astral.sh/ruff/rules/missing-return-type-private-function/)
+    "assert",       # [flake8-bandit](https://docs.astral.sh/ruff/rules/assert/)
+    "invalid-function-name",       # [pep8-naming](https://docs.astral.sh/ruff/rules/invalid-function-name/)
+    "invalid-argument-name",       # [pep8-naming](https://docs.astral.sh/ruff/rules/invalid-argument-name/)
+    "non-lowercase-variable-in-function",       # [pep8-naming](https://docs.astral.sh/ruff/rules/non-lowercase-variable-in-function/)
+    "no-self-use",    # [pylint](https://docs.astral.sh/ruff/rules/no-self-use/)
 ]
 
 [tool.ruff.format]

--- a/tests/test_optimal.py
+++ b/tests/test_optimal.py
@@ -28,7 +28,7 @@ from pydoe import (
 )
 
 
-class TestOptimalDesign(unittest.TestCase):  # noqa: PLR0904
+class TestOptimalDesign(unittest.TestCase):  # ruff: ignore[too-many-public-methods]
     def setUp(self):
         np.random.seed(42)
         self.candidates_2d = generate_candidate_set(
@@ -837,7 +837,7 @@ class TestOptimalDesign(unittest.TestCase):  # noqa: PLR0904
                     max_iter=100,
                 )
 
-    def test_all_nine_criteria_comprehensive_with_regularization(self):  # noqa: PLR0912, PLR0915
+    def test_all_nine_criteria_comprehensive_with_regularization(self):  # ruff: ignore[too-many-branches, too-many-statements]
         criteria = ["D", "A", "I", "C", "E", "G", "V", "S", "T"]
         results = {}
 

--- a/tests/test_optimal.py
+++ b/tests/test_optimal.py
@@ -28,7 +28,7 @@ from pydoe import (
 )
 
 
-class TestOptimalDesign(unittest.TestCase):  # ruff: ignore[too-many-public-methods]
+class TestOptimalDesign(unittest.TestCase):
     def setUp(self):
         np.random.seed(42)
         self.candidates_2d = generate_candidate_set(


### PR DESCRIPTION
As discussed in https://github.com/pydoe/pydoe/pull/145
new Ruff 0.16 does not accept anymore `# noqa`.
This was fixed with `ruff check --fix`.

Correcting instead of ignoring would require discussion, 
also because the instruction for the agents CLAUDE.md explicitly tells to create exceptions when necessary.

Root cause seems to be 92323488ccabc002f972ce672a1b6343a17dc332 from 3 days ago