### PR TITLE
fix: let `fracfact_opt` return saturated fractional factorial designs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,8 +6,14 @@ All notable changes to PyDOE are documented here.
 
 ## [**Latest**](https://github.com/pydoe/pydoe/compare/v1.3.0...master)
 
+### :material-wrench: Fixed
+- `fracfact_opt` no longer rejects saturated designs. The feasibility check compared the number of erased factors against $\binom{n_{\text{aliases}}}{p}$ instead of against the number of available interaction columns $2^m - m - 1$, so every resolution III design with $k = 2^m - 1$ factors in $2^m$ runs — such as $2^{7-4}_{III}$ and $2^{15-11}_{III}$ — raised *"Too many erased factors to create aliasing"*. `fracfact_opt(n, 0)` also raised `IndexError` instead of returning the full factorial ([#152](https://github.com/pydoe/pydoe/issues/152))
+
 ### :material-refresh: Changed
 - Generalize `definitive_screening_design` with arbitrary continuous-factor counts, two-level categorical factors, orthogonal and interaction-de-aliased methods, minimum-run augmentation, and fake factors while preserving historical one-argument results ([#145](https://github.com/pydoe/pydoe/pull/145)) — [@danieleongari](https://github.com/danieleongari)
+
+### :material-speedometer: Performance
+- `fracfact_aliasing` reduces each contrast to the bit pattern of its negative rows, so the elementwise product of a subset of columns becomes a bitwise exclusive or. The alias structure of a 15-factor design is now found in well under a second instead of about a minute ([#152](https://github.com/pydoe/pydoe/issues/152))
 
 ---
 

--- a/pydoe/factorial/factorial.py
+++ b/pydoe/factorial/factorial.py
@@ -15,6 +15,7 @@ Abraham Lee.
 
 from __future__ import annotations
 
+import collections
 import itertools
 import math
 import re
@@ -597,6 +598,34 @@ def fracfact_opt(
     ------
     ValueError
         If the number of factors is invalid or too many factors are erased.
+
+    Notes
+    -----
+    A :math:`2^{k-p}` design is built from :math:`m = k - p` main factors
+    spanning :math:`2^m` runs. Every erased factor is assigned to one of the
+    interaction columns of those main factors, and there are exactly
+
+    .. math::
+
+        \\sum_{j=2}^{m} \\binom{m}{j} = 2^m - m - 1
+
+    such columns. The design is therefore feasible if and only if
+    :math:`p \\le 2^m - m - 1`. The boundary case
+    :math:`p = 2^m - m - 1` consumes every interaction column and yields the
+    *saturated* resolution III design with :math:`k = 2^m - 1` factors in
+    :math:`2^m` runs, e.g. the :math:`2^{7-4}_{III}` design in 8 runs or the
+    :math:`2^{15-11}_{III}` design in 16 runs.
+
+    Examples
+    --------
+    ::
+
+        >>> gen, _alias_map, _alias_vector = fracfact_opt(7, 4)
+        >>> gen
+        'a b c abc bc ac ab'
+        >>> fracfact(gen).shape
+        (8, 7)
+
     """
 
     def n_comb(n: int, k: int) -> int:
@@ -614,12 +643,18 @@ def fracfact_opt(
         raise ValueError("Number of erased factors must be non-negative")
 
     n_main_factors = n_factors - n_erased
+    # Number of interaction columns available to carry the erased factors:
+    # sum_{j=2}^{m} C(m, j) = 2^m - m - 1 for m main factors.
     n_aliases = sum(
         n_comb(n_main_factors, n) for n in range(2, n_main_factors + 1)
     )
 
-    if n_erased > n_comb(n_aliases, n_erased):
-        raise ValueError("Too many erased factors to create aliasing")
+    if n_erased > n_aliases:
+        raise ValueError(
+            "Too many erased factors to create aliasing: "
+            f"{n_main_factors} main factors provide only {n_aliases} "
+            f"interaction columns, but {n_erased} are needed"
+        )
 
     all_names = string.ascii_lowercase
     # factors = range(n_factors)
@@ -643,10 +678,10 @@ def fracfact_opt(
     )
 
     for aliasing in all_combinations:
-        aliasing_design = " ".join([
-            "".join([all_names[f] for f in a]) for a in aliasing
-        ])
-        complete_design = main_design + " " + aliasing_design
+        aliasing_design = ["".join([all_names[f] for f in a]) for a in aliasing]
+        # ``aliasing_design`` is empty when n_erased == 0; joining the parts
+        # this way keeps the generator free of a trailing separator.
+        complete_design = " ".join([main_design, *aliasing_design])
         design = fracfact(complete_design)
         if design.shape != design_shape:
             raise ValueError(
@@ -694,27 +729,45 @@ def fracfact_aliasing(design: np.ndarray) -> tuple[list[str], np.ndarray]:
     Raises
     ------
     ValueError
-        If the design is too large (more than 20 factors).
+        If the design is too large (more than 20 factors), or if it contains
+        entries other than -1 and +1.
+
+    Notes
+    -----
+    Every one of the :math:`2^{k} - 1` factors and interactions is reduced to
+    the bit pattern of the rows in which its contrast is negative. Because the
+    columns only hold :math:`\\pm 1`, the elementwise product of a set of
+    columns is the bitwise *exclusive or* of their patterns, so the whole
+    alias structure is found with integer arithmetic instead of one NumPy
+    reduction per subset.
     """
     _n_rounds, n_factors = design.shape
 
     if n_factors > 20:
         raise ValueError("Design too big, use 20 factors or less")
 
+    if not np.all(np.abs(design) == 1):
+        raise ValueError("Design must only contain the levels -1 and +1")
+
     all_names = string.ascii_lowercase
     factors = range(n_factors)
+
+    # Bit i of column_bits[j] is set when design[i, j] is at its low level.
+    column_bits = [
+        sum(1 << int(row) for row in np.flatnonzero(design[:, j] < 0))
+        for j in factors
+    ]
+
     all_combinations = itertools.chain.from_iterable(
         itertools.combinations(factors, n) for n in range(1, n_factors + 1)
     )
     aliases = {}
 
     for combination in all_combinations:
-        contrast = np.prod(design[:, combination], axis=1)
-        contrast.flags.writeable = False
-        aliases[contrast.data.tobytes()] = aliases.get(
-            contrast.data.tobytes(), []
-        )
-        aliases[contrast.data.tobytes()].append(combination)
+        contrast = 0
+        for factor in combination:
+            contrast ^= column_bits[factor]
+        aliases.setdefault(contrast, []).append(combination)
 
     aliases_list = []
     for alias in aliases.values():
@@ -731,12 +784,18 @@ def fracfact_aliasing(design: np.ndarray) -> tuple[list[str], np.ndarray]:
             "".join([all_names[f] for f in a]) for a in alias
         ])
         aliases_readable.append(alias_readable)
-        for sizes in itertools.combinations([len(a) for a in alias], 2):
-            if not (sizes[0] >= 0 and sizes[1] >= 0):
-                raise ValueError(f"Invalid alias sizes: {sizes}")
-            if sizes[0] > sizes[1]:
-                raise ValueError(f"Alias sizes not in order: {sizes}")
-            alias_matrix[sizes[0] - 1, sizes[1] - 1] += 1
+        # Count the aliased pairs by interaction order rather than iterating
+        # over every pair: an alias chain holding `count[s]` terms of order
+        # `s` contributes count[s] * count[t] pairs of orders (s, t), and
+        # count[s] * (count[s] - 1) / 2 pairs of equal order s.
+        counts = collections.Counter(len(a) for a in alias)
+        orders = sorted(counts)
+        for i, low in enumerate(orders):
+            alias_matrix[low - 1, low - 1] += (
+                counts[low] * (counts[low] - 1) // 2
+            )
+            for high in orders[i + 1 :]:
+                alias_matrix[low - 1, high - 1] += counts[low] * counts[high]
 
     alias_vector = alias_matrix[alias_vector_indices(n_factors)]
 

--- a/tests/test_factorial.py
+++ b/tests/test_factorial.py
@@ -121,6 +121,54 @@ class TestFactorial(unittest.TestCase):
             np.array([0.0, 0.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
         )
 
+    def test_issue_152_saturated_designs(self):
+        """A 2^(k-p) design with k = 2^m - 1 factors in 2^m runs is legal.
+
+        These are the *saturated* resolution III designs: every one of the
+        2^m - m - 1 interaction columns of the m main factors carries an
+        erased factor.
+        """
+        for n_factors, n_erased, n_runs in [(3, 1, 4), (7, 4, 8), (15, 11, 16)]:
+            gen, alias_map, alias_vector = fracfact_opt(n_factors, n_erased)
+            design = fracfact(gen)
+            self.assertEqual(design.shape, (n_runs, n_factors))
+            self.assertEqual(len(gen.split()), n_factors)
+            # a saturated design uses every available interaction column
+            self.assertEqual(len(set(gen.split())), n_factors)
+            # main effects must never be aliased with one another
+            self.assertEqual(alias_vector[0], 0.0)
+            self.assertTrue(alias_map)
+
+    def test_issue_152_expected_saturated_generators(self):
+        """The 2^(7-4) and 2^(15-11) designs use every interaction column."""
+        gen, _, _ = fracfact_opt(7, 4)
+        self.assertEqual(
+            set(gen.split()), {"a", "b", "c", "ab", "ac", "bc", "abc"}
+        )
+
+        gen, _, _ = fracfact_opt(15, 11)
+        self.assertEqual(len(set(gen.split())), 15)
+        self.assertEqual(fracfact(gen).shape, (16, 15))
+
+    def test_fracfact_opt_no_erased_factors(self):
+        """n_erased = 0 must return the full factorial, not raise."""
+        gen, alias_map, alias_vector = fracfact_opt(3, 0)
+        self.assertEqual(gen, "a b c")
+        np.testing.assert_allclose(fracfact(gen), ff2n(3))
+        self.assertEqual(len(alias_map), 2**3 - 1)
+        np.testing.assert_array_equal(alias_vector, np.zeros(6))
+
+    def test_fracfact_opt_too_many_erased_factors(self):
+        """Beyond the saturated design there is nothing left to alias."""
+        with pytest.raises(
+            ValueError, match="Too many erased factors to create aliasing"
+        ):
+            fracfact_opt(4, 2)  # 2 main factors provide only 1 interaction
+        with pytest.raises(
+            ValueError, match="Too many erased factors to create aliasing"
+        ):
+            fracfact_opt(8, 5)  # 3 main factors provide only 4 interactions
+
     def test_fracfact_by_res_resolution_III(self):
         """Test resolution III designs"""
         # 8 runs should support 4 factors at resolution III


### PR DESCRIPTION
Fixes #152

## The bug

`fracfact_opt(n_factors, n_erased)` builds a $2^{k-p}$ design from $m = k - p$ main factors and assigns every erased factor to one of their interaction columns. There are exactly

$$\sum_{j=2}^{m}\binom{m}{j} = 2^m - m - 1$$

such columns, so the design is feasible **iff** $p \le 2^m - m - 1$.

The guard compared `n_erased` against $\binom{n_\text{aliases}}{p}$ — the number of *candidate designs*, not the number of *available columns*:

```python
if n_erased > n_comb(n_aliases, n_erased):
    raise ValueError("Too many erased factors to create aliasing")
```

At the boundary $p = 2^m - m - 1$ there is exactly one candidate design, so $\binom{n_\text{aliases}}{p} = 1$ and the check fired for every **saturated** design — precisely the well-known resolution III designs with $k = 2^m - 1$ factors in $2^m$ runs:

| call | design | runs | factors | before | after |
|---|---|---|---|---|---|
| `fracfact_opt(3, 1)` | $2^{3-1}_{III}$ | 4 | 3 | ok | ok |
| `fracfact_opt(7, 4)` | $2^{7-4}_{III}$ | 8 | 7 | :x: `ValueError` | :white_check_mark: `a b c abc bc ac ab` |
| `fracfact_opt(15, 11)` | $2^{15-11}_{III}$ | 16 | 15 | :x: `ValueError` | :white_check_mark: 15 columns, 16 runs |

Only $m = 2$ escaped, because there $\binom{1}{1} = 1 \ge 1$ — which is why the reporter saw `fracfact_opt(3, 1)` work while everything above it failed.

Both designs are textbook standards: NIST/SEMATECH e-Handbook [§5.3.3.4.4](https://www.itl.nist.gov/div898/handbook/pri/section3/pri3347.htm) and Montgomery, *Design and Analysis of Experiments*, Table 8.14. The 8-run one is the same design `pbdesign(7)` produces, as this repo's own [factorial reference](https://pydoe.github.io/pydoe/reference/factorial/) already notes.

## The fix

```python
if n_erased > n_aliases:
    raise ValueError(...)
```

plus the actual counts in the message, so a genuinely infeasible request explains itself.

## Two related defects fixed alongside

**`fracfact_opt(n, 0)` raised `IndexError`.** With no erased factors the generator was assembled as `main_design + " " + ""`, leaving a trailing space that made `fracfact()` index into an empty token. Joining the parts instead returns the full factorial, as expected.

**`fracfact_aliasing` was the bottleneck for the newly reachable designs.** It recomputed a NumPy product for each of the $2^k - 1$ subsets and then counted aliased pairs one at a time — about 38 s for a 15-factor design, which would have made this fix technically correct but unusable, and added ~105 s to CI.

Since the columns hold only $\pm 1$, each contrast is fully described by the bit pattern of the rows where it is negative, and the elementwise product of a subset of columns is the bitwise **exclusive or** of their patterns. Pairs of aliased terms are counted per interaction order rather than pairwise: a chain with $c_s$ terms of order $s$ contributes $c_s c_t$ pairs of orders $(s,t)$ and $\binom{c_s}{2}$ pairs of equal order.

| | before | after |
|---|---|---|
| `fracfact_aliasing` on 15 factors | 37.6 s | 0.17 s (**220×**) |
| `tests/test_factorial.py` | 120 s | 3.8 s |

Output is **byte-identical**: verified against the previous implementation over 2016 designs — every regular design on 2, 3 and 4 base factors, sampled 5-base-factor designs, sign-flipped and out-of-order generators (`a b -ab`, `b a ab`), and full factorials up to $2^8$.

The function now also rejects designs holding levels other than $\pm 1$, which it never handled meaningfully; this is documented in its `Raises` section.

## Tests

- `test_issue_152_saturated_designs` — $2^{3-1}$, $2^{7-4}$ and $2^{15-11}$ return the right shape, use every interaction column, and leave no main effect aliased with another
- `test_issue_152_expected_saturated_generators` — the exact generator set for $2^{7-4}$
- `test_fracfact_opt_no_erased_factors` — `fracfact_opt(3, 0)` returns the full factorial
- `test_fracfact_opt_too_many_erased_factors` — genuinely infeasible requests still raise
- a doctest on `fracfact_opt` covering `(7, 4)`

`491 passed` on the full suite; `ruff check` and `ruff format` clean.
