### PR TITLE
ci: add scheduled Python versions sync workflow

### DIFF
--- a/.github/scripts/sync_python_versions.py
+++ b/.github/scripts/sync_python_versions.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Sync the Python versions declared in pyproject.toml with the versions
+upstream still supports.
+
+Reads the active (non-EOL) versions from the ACTIVE_VERSIONS environment
+variable -- a JSON array of "3.x" labels as produced by endoflife.date --
+and rewrites, in place:
+
+  * project.classifiers, so the "Programming Language :: Python :: X.Y"
+    entries drop versions that have gone EOL and pick up newly released
+    ones;
+  * project.requires-python, raised to the oldest still-supported version
+    when the current floor has gone EOL.
+
+The floor is only ever raised, never lowered. A project that deliberately
+requires a newer Python than the oldest supported one -- say ">=3.12" while
+3.10 is still alive -- keeps its own floor, and only the versions at or
+above it are declared.
+
+Nothing is written when the declaration already matches, so the calling
+workflow opens a pull request only on a real change.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import tomlkit
+
+PYPROJECT = Path("pyproject.toml")
+VERSION_CLASSIFIER = re.compile(r"^Programming Language :: Python :: (\d+\.\d+)$")
+FLOOR = re.compile(r">=\s*(\d+\.\d+)")
+
+
+def key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def emit(name: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def fail(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    raw = os.environ.get("ACTIVE_VERSIONS", "").strip()
+    if not raw:
+        fail("ACTIVE_VERSIONS is unset")
+
+    try:
+        labels = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        fail(f"ACTIVE_VERSIONS is not valid JSON: {exc}")
+
+    # endoflife.date also carries the 2.x tail on some products; only the
+    # 3.x line is meaningful for a project that declares "3 :: Only".
+    active = sorted({v for v in labels if re.fullmatch(r"3\.\d+", str(v))}, key=key)
+    if not active:
+        fail("no active Python 3.x versions in ACTIVE_VERSIONS")
+
+    if not PYPROJECT.is_file():
+        fail("pyproject.toml not found")
+
+    document = tomlkit.parse(PYPROJECT.read_text(encoding="utf-8"))
+    project = document.get("project")
+    if project is None:
+        fail("pyproject.toml has no [project] table")
+
+    # --- requires-python -------------------------------------------------
+    requires = str(project.get("requires-python", "")).strip()
+    match = FLOOR.search(requires)
+    current_floor = match.group(1) if match else None
+    floor = max([f for f in (current_floor, active[0]) if f], key=key)
+    supported = [v for v in active if key(v) >= key(floor)]
+    if not supported:
+        fail(f"requires-python floor {current_floor} excludes every active version")
+
+    # --- classifiers -----------------------------------------------------
+    classifiers = project.get("classifiers")
+    if classifiers is None:
+        fail("[project] has no classifiers list")
+
+    existing = [str(item) for item in classifiers]
+    positions = [i for i, item in enumerate(existing) if VERSION_CLASSIFIER.match(item)]
+    declared = [VERSION_CLASSIFIER.match(existing[i]).group(1) for i in positions]
+
+    if declared == supported and current_floor == floor:
+        print(f"Already in sync: {', '.join(supported)} (requires-python >={floor})")
+        emit("changed", "false")
+        return
+
+    wanted = [f"Programming Language :: Python :: {v}" for v in supported]
+    if positions:
+        # Every version classifier sits at or after the first one, so the
+        # slice before it survives removal unshifted.
+        anchor = positions[0]
+        kept = [c for i, c in enumerate(existing) if i not in set(positions)]
+        rebuilt = kept[:anchor] + wanted + kept[anchor:]
+    else:
+        # No per-version entries yet: seed them after the generic
+        # "Programming Language :: Python :: 3" marker when there is one.
+        try:
+            anchor = existing.index("Programming Language :: Python :: 3") + 1
+        except ValueError:
+            anchor = len(existing)
+        rebuilt = existing[:anchor] + wanted + existing[anchor:]
+
+    array = tomlkit.array()
+    for item in rebuilt:
+        array.append(item)
+    array.multiline(True)
+    project["classifiers"] = array
+
+    if current_floor != floor:
+        project["requires-python"] = f">={floor}"
+
+    PYPROJECT.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+    added = [v for v in supported if v not in declared]
+    dropped = [v for v in declared if v not in supported]
+
+    lines = [
+        "The Python versions declared in `pyproject.toml` no longer match the",
+        "versions upstream supports, per [endoflife.date](https://endoflife.date/python).",
+        "",
+    ]
+    if added:
+        lines.append(f"- **Added:** {', '.join(added)}")
+    if dropped:
+        lines.append(f"- **Dropped (end-of-life):** {', '.join(dropped)}")
+    if current_floor != floor:
+        lines.append(f"- **`requires-python`:** `>={current_floor}` -> `>={floor}`")
+    lines += [
+        "",
+        f"Declared set is now: {', '.join(supported)}.",
+        "",
+        "Opened automatically by the `Python Versions Sync` workflow.",
+    ]
+    body = "\n".join(lines) + "\n"
+
+    body_file = os.environ.get("PR_BODY_FILE")
+    if body_file:
+        Path(body_file).write_text(body, encoding="utf-8")
+
+    emit("changed", "true")
+    sys.stdout.write(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/python-versions-sync.yml
+++ b/.github/workflows/python-versions-sync.yml
@@ -1,0 +1,105 @@
+name: Python Versions Sync
+
+# Keeps the Python versions declared in pyproject.toml in step with the
+# versions upstream still supports.
+#
+# The active set is fetched from endoflife.date rather than hardcoded --
+# the same source the build matrix in the test workflow uses -- so the
+# classifiers, the requires-python floor and the CI matrix cannot drift
+# apart from each other.
+#
+# When the declaration differs from the active set this opens a PR as
+# github-actions[bot]. Note that a PR opened with GITHUB_TOKEN does not
+# itself trigger further workflow runs; close and reopen it if you need
+# the full check suite to run against the branch.
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"  # Mondays at 03:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync Python versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Fetch supported Python versions
+        id: fetch-versions
+        run: |
+          # Without pipefail this pipeline reports jq's exit status rather
+          # than curl's, so a network failure is masked: jq reads empty
+          # input and emits [], which reads as "every version is EOL" and
+          # would strip the classifiers wholesale.
+          set -euo pipefail
+
+          versions=$(curl -fsSL --retry 3 --retry-all-errors --connect-timeout 15 \
+                       https://endoflife.date/api/v1/products/python/ \
+                     | jq -c '[ .result.releases[] | select(.isEol == false) | .label ]')
+
+          if [ "$(echo "$versions" | jq 'length')" -eq 0 ]; then
+            echo "::error::endoflife.date returned no supported Python versions"
+            exit 1
+          fi
+
+          echo "active=$versions" >> "$GITHUB_OUTPUT"
+          echo "Active Python versions: $versions"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Apply to pyproject.toml
+        id: update
+        env:
+          ACTIVE_VERSIONS: ${{ steps.fetch-versions.outputs.active }}
+          PR_BODY_FILE: ${{ runner.temp }}/pr-body.md
+        run: |
+          set -euo pipefail
+          pip install --quiet tomlkit
+          python .github/scripts/sync_python_versions.py
+
+      - name: Open pull request
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE: ${{ github.event.repository.default_branch }}
+          PR_BODY_FILE: ${{ runner.temp }}/pr-body.md
+        run: |
+          set -euo pipefail
+          BRANCH="chore/python-versions-sync"
+          TITLE="chore: sync Python versions in pyproject.toml"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          git add pyproject.toml
+          if git diff --cached --quiet; then
+            echo "Nothing staged; the tree already matches."
+            exit 0
+          fi
+
+          git commit -m "$TITLE" -m "$(cat "$PR_BODY_FILE")"
+
+          # The branch is bot-owned and always rebuilt from the default
+          # branch, so an existing one is intentionally replaced.
+          git push --force-with-lease origin "$BRANCH"
+
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Updated existing PR #$existing"
+          else
+            gh pr create --base "$BASE" --head "$BRANCH" \
+              --title "$TITLE" --body-file "$PR_BODY_FILE"
+          fi


### PR DESCRIPTION
Adds a scheduled workflow that keeps the Python versions declared in `pyproject.toml` from drifting away from the versions upstream still supports.

## What changed

- `.github/workflows/python-versions-sync.yml` — runs Mondays at 03:00 UTC and on `workflow_dispatch`.
- `.github/scripts/sync_python_versions.py` — the helper the workflow runs.

## How it works

The active version set is fetched from endoflife.date rather than hardcoded, so the `requires-python` floor and the `Programming Language :: Python` classifiers stay in step with the same source the test matrix uses. When the declaration differs from the active set, the workflow opens a PR as `github-actions[bot]` on the `chore/python-versions-sync` branch.

Note: a PR opened with `GITHUB_TOKEN` does not itself trigger further workflow runs — close and reopen it if the full check suite needs to run against the branch.

No existing workflows, packaging metadata, or docs were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)