### PR TITLE
Check dependencies monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
 
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"


### PR DESCRIPTION
## Summary

Sets both `schedule.interval` entries in `.github/dependabot.yml` — `github-actions` and `uv` — to `monthly`.

`schedule.day: "friday"` is dropped from both. That key only applies when the interval is `weekly`, so leaving it next to `monthly` would be a dead setting that still reads as though it controls when updates land.

## Test plan

Config parses as valid YAML; `version: 2` intact; both entries under `updates` now read `interval: monthly` with no leftover `day` key. Ecosystems and directories are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)